### PR TITLE
Update OUI URL

### DIFF
--- a/gen-ula.sh
+++ b/gen-ula.sh
@@ -56,7 +56,7 @@ fi
 
 
 if [ ! -r "oui.txt" ]; then
-    wget "http://standards.ieee.org/regauth/oui/oui.txt"
+    wget "http://standards-oui.ieee.org/oui.txt"
 fi
 
 # MAC Vendor check


### PR DESCRIPTION
The URL of the OUI database has changed.
Old URL is 404.